### PR TITLE
Update MasterEscrow.sol

### DIFF
--- a/MasterEscrow.sol
+++ b/MasterEscrow.sol
@@ -102,7 +102,7 @@ contract Escrow {
 	function confirmPurchase()
     	public
     	inState(State.Created)
-    	condition(msg.value == (0 * value))
+    	condition(msg.value == (2 * value))
     	payable
 	{
     	emit PurchaseConfirmed();
@@ -125,6 +125,7 @@ contract Escrow {
 
     	// NOTE: This actually allows both the purchaser and the seller to
     	// block the refund - the withdraw pattern should be used.
+    	purchaser.transfer(value);
     	seller.transfer(address(this).balance);
 	}
 }


### PR DESCRIPTION
*Seller stakes ETH value of Asset in new escrow contract ('asset purchase price'). 
*Purchaser stakes double ETH value of Asset and locks contract balance (seller collateral + purchaser collateral + asset purchase price).
*Seller cannot unlock contract balance. 
*Purchaser cannot retrieve collateral without also sending purchase price to Seller (completing transaction). 

Seller is trusted to send Asset, but is incentivized to do so in order to retrieve collateral of equal value. 
Purchaser is trusted to release contract balance ('pay purchase price'), but is incentivized to do so in order to retrieve collateral of equal value. 
Upon confirming receipt of Asset, Purchaser releases balance: retrieving purchaser collateral, transferring purchase price, and releasing seller collateral. 

Example: 
If an Item is worth 0.2 ETH, a Seller can stake 0.2 ETH ('advertised price') and will not be able to change advertised price unless they abort and relist escrow contract before Purchaser accepts and locks it. 

A Purchaser can then accept this offer by sending 0.4 ETH to contract. When the Item is actually delivered to Purchaser, 0.2 ETH is returned, allowing Purchaser to effectively use an automated escrow to pay Seller 0.2 ETH with better assurance that the item will actually be delivered, and for the Seller, that Purchaser will not take too long to confirm Item was delivered.